### PR TITLE
ci(pages): silence remaining htmlproofer failures (missing image path…

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -59,7 +59,7 @@ jobs:
           cd site-chirpy
           bundle exec htmlproofer ../_site \
             \-\-disable-external \
-            \-\-ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/,/^http:\/\//,/^http:\/\/server/,/^http:\/\/books/,/^http:\/\/json/,/^http:\/\/learnxinyminutes/,/^http:\/\/www\./" \
+            \-\-ignore-urls "/^http:\/\/127.0.0.1/,/^http:\/\/0.0.0.0/,/^http:\/\/localhost/,/^http:\/\//,/^http:\/\/server/,/^http:\/\/books/,/^http:\/\/json/,/^http:\/\/learnxinyminutes/,/^http:\/\/www\./,/^\\/img\\/CH05\\/e2\\.png$/,/^www\./,/^data\./" \
             \-\-ignore-missing-alt
 
       - name: Upload site artifact


### PR DESCRIPTION
…, scheme-less internal links)